### PR TITLE
GH-27: fix(harness): nav-spike PreToolUse probe hard-blocks Read when its script is missing — guard for fail-open

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Navigator Plugin - Quality Gate Targets
 # These targets support the CI/CD quality gates
 
-.PHONY: build test lint clean
+.PHONY: build test lint clean conformance-check
 
 # Build target - for a plugin, validate JSON and check Python syntax
 build:
@@ -20,6 +20,7 @@ build:
 # discovery.)
 TEST_DIRS := \
 	hooks \
+	tests/harness-conformance \
 	skills/nav-upgrade/functions \
 	skills/nav-sync-claude/functions \
 	skills/nav-simplify/scripts \
@@ -53,6 +54,21 @@ test:
 	done; \
 	if [ $$fail -ne 0 ]; then echo "TESTS FAILED"; exit 1; fi; \
 	echo "All unit tests passed."
+
+# Conformance gate (TASK-58) — a results file must exist for the installed
+# Claude Code version. Probes are live-driven and cannot run in CI; when this
+# fails, re-drive the suite per tests/harness-conformance/run.md.
+conformance-check:
+	@v=$$(claude --version | awk '{print $$1}'); \
+	f="tests/harness-conformance/results/cc-$$v.json"; \
+	if [ -f "$$f" ]; then \
+		echo "conformance-check: OK ($$f)"; \
+	else \
+		echo "conformance-check: MISSING conformance results for Claude Code $$v"; \
+		echo "expected file: $$f"; \
+		echo "re-drive the suite: tests/harness-conformance/run.md"; \
+		exit 1; \
+	fi
 
 # Lint target - check code style
 lint:

--- a/tests/harness-conformance/common.py
+++ b/tests/harness-conformance/common.py
@@ -1,0 +1,180 @@
+"""Shared driver helpers for the harness-conformance probes (TASK-58).
+
+Ported verbatim from the validated TASK-57 spike bodies
+(/tmp/nav-v7-spike/probes/common.py). Stdlib only — deliberately NO imports
+from hooks/ or nav_hook_lib: this suite runs parallel to TASK-59 and must
+stay independent of the runtime it certifies.
+
+Each probe: arms its hook via a state file, drives a live headless Claude Code
+session in the scratch project, then checks BOTH observables — the visible
+answer (quote-check) and the transcript JSONL (position-aware grep).
+
+The spike dir is parametrized via NAV_SPIKE_DIR (default /tmp/nav-v7-spike);
+the /tmp harness stays the runtime home. See run.md for setup/teardown.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+SPIKE = Path(os.environ.get("NAV_SPIKE_DIR", "/tmp/nav-v7-spike"))
+PROJECT = SPIKE / "project"
+STATE = SPIKE / "state"
+CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
+
+
+def make_sentinel(tag: str) -> str:
+    return f"NAV-S{tag}-{uuid.uuid4().hex[:8]}"
+
+
+def arm(probe: str, data: dict) -> None:
+    STATE.mkdir(parents=True, exist_ok=True)
+    (STATE / f"arm-{probe}.json").write_text(json.dumps(data))
+
+
+def disarm(probe: str) -> None:
+    f = STATE / f"arm-{probe}.json"
+    if f.exists():
+        f.unlink()
+
+
+def clear_log(probe: str) -> None:
+    f = STATE / f"log-{probe}.jsonl"
+    if f.exists():
+        f.unlink()
+
+
+def read_log(probe: str) -> list:
+    f = STATE / f"log-{probe}.jsonl"
+    if not f.exists():
+        return []
+    return [json.loads(l) for l in f.read_text().splitlines() if l.strip()]
+
+
+def preflight() -> None:
+    """mem-036: scratch project must have no settings backstop and no .agent."""
+    assert not (PROJECT / ".claude" / "settings.json").exists(), \
+        "scratch project must not have .claude/settings.json"
+    assert not (PROJECT / ".agent").exists(), \
+        "scratch project must not have .agent/"
+
+
+def cc_version() -> str:
+    out = subprocess.run(["claude", "--version"], capture_output=True, text=True)
+    return out.stdout.strip()
+
+
+def run_claude(prompt: str, allowed=None, resume=None, timeout=240) -> dict:
+    """Drive one headless turn in the scratch project. Returns raw + parsed."""
+    cmd = ["claude", "-p", prompt, "--output-format", "json"]
+    if allowed:
+        cmd += ["--allowedTools", ",".join(allowed)]
+    if resume:
+        cmd += ["--resume", resume]
+    started = time.time()
+    proc = subprocess.run(cmd, cwd=PROJECT, capture_output=True, text=True,
+                          timeout=timeout)
+    parsed = None
+    try:
+        parsed = json.loads(proc.stdout)
+    except Exception:
+        pass
+    return {
+        "cmd": cmd,
+        "exit_code": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "parsed": parsed,
+        "result_text": (parsed or {}).get("result", "") if isinstance(parsed, dict) else "",
+        "session_id": (parsed or {}).get("session_id") if isinstance(parsed, dict) else None,
+        "started": started,
+        "duration": time.time() - started,
+    }
+
+
+def find_transcripts(session_id=None, since=None) -> list:
+    """Locate transcript JSONLs for the scratch project.
+
+    session_id -> exact file match anywhere under ~/.claude/projects.
+    since      -> all scratch-project JSONLs modified after that epoch
+                  (catches subagent/sidechain files too).
+    """
+    hits = []
+    if session_id:
+        hits += list(CLAUDE_PROJECTS.glob(f"*/{session_id}.jsonl"))
+        hits += list(CLAUDE_PROJECTS.glob(f"*/**/{session_id}.jsonl"))
+    if since is not None:
+        for d in CLAUDE_PROJECTS.glob(f"*{SPIKE.name}*"):
+            for f in d.rglob("*.jsonl"):
+                if f.stat().st_mtime >= since - 1:
+                    hits.append(f)
+    seen, out = set(), []
+    for h in hits:
+        if h not in seen:
+            seen.add(h)
+            out.append(h)
+    return out
+
+
+def scan_jsonl(path: Path, needle: str) -> list:
+    """Position-aware grep: where does the needle sit inside the transcript?"""
+    occurrences = []
+    for i, line in enumerate(path.read_text().splitlines(), 1):
+        if needle not in line:
+            continue
+        entry_type = role = None
+        block_types = []
+        sidechain = None
+        try:
+            entry = json.loads(line)
+            entry_type = entry.get("type")
+            sidechain = entry.get("isSidechain")
+            msg = entry.get("message") or {}
+            role = msg.get("role")
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if needle in json.dumps(block):
+                        block_types.append(block.get("type"))
+            elif isinstance(content, str) and needle in content:
+                block_types.append("str")
+            if not block_types and needle in json.dumps(entry):
+                for key in entry:
+                    if key != "message" and needle in json.dumps(entry.get(key)):
+                        block_types.append(f"entry.{key}")
+        except Exception:
+            block_types.append("unparsed-line")
+        occurrences.append({
+            "file": str(path), "line": i, "entry_type": entry_type,
+            "role": role, "is_sidechain": sidechain, "block_types": block_types,
+        })
+    return occurrences
+
+
+def entry_lines(path: Path, predicate) -> list:
+    """Line numbers of entries matching predicate(entry)."""
+    out = []
+    for i, line in enumerate(path.read_text().splitlines(), 1):
+        try:
+            entry = json.loads(line)
+        except Exception:
+            continue
+        try:
+            if predicate(entry):
+                out.append(i)
+        except Exception:
+            continue
+    return out
+
+
+def write_verdict(probe: str, data: dict) -> None:
+    data = {"probe": probe, "cc_version": cc_version(),
+            "date": time.strftime("%Y-%m-%d"), **data}
+    STATE.mkdir(parents=True, exist_ok=True)
+    out = STATE / f"verdict-{probe}.json"
+    out.write_text(json.dumps(data, indent=2, default=str))
+    print(json.dumps(data, indent=2, default=str))

--- a/tests/harness-conformance/harness/.claude-plugin/marketplace.json
+++ b/tests/harness-conformance/harness/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "nav-spike-marketplace",
+  "displayName": "Navigator v7 Spike (TASK-57, temporary)",
+  "owner": {
+    "name": "Aleks Petrov",
+    "email": "aleks@quantflow.studio"
+  },
+  "metadata": {
+    "description": "Scratch marketplace for TASK-57 hook-channel probes. Not for distribution.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "nav-spike",
+      "source": "./nav-spike",
+      "description": "TASK-57 v7 hook-channel spike probes (S1-S6). Hooks are inert outside /tmp/nav-v7-spike."
+    }
+  ]
+}

--- a/tests/harness-conformance/harness/nav-spike/.claude-plugin/plugin.json
+++ b/tests/harness-conformance/harness/nav-spike/.claude-plugin/plugin.json
@@ -1,0 +1,78 @@
+{
+  "name": "nav-spike",
+  "version": "0.1.0",
+  "description": "TASK-57 v7 hook-channel spike probes (S1-S6). Every hook gates on cwd inside /tmp/nav-v7-spike AND a per-probe arm file, so the plugin is inert everywhere else.",
+  "author": {
+    "name": "Aleks Petrov"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'case \"$PWD\" in /tmp/nav-v7-spike/*) mkdir -p /tmp/nav-v7-spike/state; printf \"ROOT=%s PWD=%s\\n\" \"${CLAUDE_PLUGIN_ROOT}\" \"$PWD\" >> /tmp/nav-v7-spike/state/log-s6.txt;; esac'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"${CLAUDE_PLUGIN_ROOT}/hooks/s1_posttooluse.py\"; [ -f \"$f\" ] && exec python3 \"$f\" || exit 0'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"${CLAUDE_PLUGIN_ROOT}/hooks/s2_stop.py\"; [ -f \"$f\" ] && exec python3 \"$f\" || exit 0'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"${CLAUDE_PLUGIN_ROOT}/hooks/s3_subagentstart.py\"; [ -f \"$f\" ] && exec python3 \"$f\" || exit 0'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"${CLAUDE_PLUGIN_ROOT}/hooks/s4_userpromptsubmit.py\"; [ -f \"$f\" ] && exec python3 \"$f\" || exit 0'",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'f=\"${CLAUDE_PLUGIN_ROOT}/hooks/s5_pretooluse.py\"; [ -f \"$f\" ] && exec python3 \"$f\" || exit 0'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/harness-conformance/harness/nav-spike/hooks/s1_posttooluse.py
+++ b/tests/harness-conformance/harness/nav-spike/hooks/s1_posttooluse.py
@@ -1,0 +1,35 @@
+"""S1 — PostToolUse(Read) additionalContext injection probe (TASK-57).
+
+Emits hookSpecificOutput.additionalContext carrying the per-run sentinel plus
+an instruction to quote it. Pass = sentinel quoted in the visible answer AND
+transcript grep finds it positioned at/after the tool_result (injected), not
+merely echoed.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from spike_gate import gate, log
+
+payload, arm = gate("s1")
+sentinel = arm["sentinel"]
+
+# Declarative fact, no imperative: the model's injection defense flags
+# "you MUST quote X" from tool-adjacent hooks as prompt injection (observed
+# 2/2 on CC 2.1.205), which conflates delivery with compliance. The driving
+# prompt asks a question only answerable from this fact.
+out = {
+    "hookSpecificOutput": {
+        "hookEventName": "PostToolUse",
+        "additionalContext": (
+            f"Session metadata: the internal build codename for this "
+            f"session is {sentinel}."
+        ),
+    }
+}
+print(json.dumps(out))
+log("s1", {"event": "emitted-additionalContext", "sentinel": sentinel,
+           "tool_name": payload.get("tool_name")})
+sys.exit(0)

--- a/tests/harness-conformance/harness/nav-spike/hooks/s2_stop.py
+++ b/tests/harness-conformance/harness/nav-spike/hooks/s2_stop.py
@@ -1,0 +1,46 @@
+"""S2 — Stop forced-continuation probe with single-shot fuse (TASK-57, mem-037).
+
+Variants (from arm file):
+  "continue" — emit {"continue": true, "reason": <instruction+sentinel>}
+  "block"    — emit {"decision": "block", "reason": <instruction+sentinel>}
+                (the routing-matrix fallback; probed for evidence too)
+
+Fuse: /tmp/nav-v7-spike/state/fuse-s2 — present => silent exit 0 (single shot).
+Belt on top of the fuse: stop_hook_active in the payload also short-circuits,
+so even a broken fuse cannot loop (mem-037).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from spike_gate import gate, log, STATE
+
+payload, arm = gate("s2")
+
+if payload.get("stop_hook_active"):
+    log("s2", {"event": "stop_hook_active-short-circuit"})
+    sys.exit(0)
+
+fuse = STATE / "fuse-s2"
+if fuse.exists():
+    log("s2", {"event": "fuse-present-silent-exit"})
+    sys.exit(0)
+fuse.write_text("consumed")
+
+sentinel = arm["sentinel"]
+variant = arm.get("variant", "continue")
+instruction = (
+    f"Output exactly one more message containing the exact token {sentinel} "
+    "and nothing else, then stop."
+)
+
+if variant == "continue":
+    out = {"continue": True, "reason": instruction}
+else:
+    out = {"decision": "block", "reason": instruction}
+
+print(json.dumps(out))
+log("s2", {"event": "emitted", "variant": variant, "sentinel": sentinel})
+sys.exit(0)

--- a/tests/harness-conformance/harness/nav-spike/hooks/s3_subagentstart.py
+++ b/tests/harness-conformance/harness/nav-spike/hooks/s3_subagentstart.py
@@ -1,0 +1,34 @@
+"""S3 — SubagentStart additionalContext probe (TASK-57).
+
+Injects sentinel A into the starting subagent's context. Pass = A appears in
+the subagent's output and NOT in main-thread turns; the main-thread-only
+sentinel B (carried by the driving prompt) must be absent from the subagent
+transcript (both-way isolation).
+
+The gate log doubles as existence evidence: if this event never fires, the
+log stays empty and the channel is dead at the manifest level.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from spike_gate import gate, log
+
+payload, arm = gate("s3")
+sentinel = arm["sentinel"]
+
+out = {
+    "hookSpecificOutput": {
+        "hookEventName": "SubagentStart",
+        "additionalContext": (
+            f"SPIKE SUBAGENT TOKEN: {sentinel}. "
+            "You MUST quote this exact token verbatim once in your final answer."
+        ),
+    }
+}
+print(json.dumps(out))
+log("s3", {"event": "emitted-additionalContext", "sentinel": sentinel,
+           "agent_type": payload.get("agent_type") or payload.get("subagent_type")})
+sys.exit(0)

--- a/tests/harness-conformance/harness/nav-spike/hooks/s4_userpromptsubmit.py
+++ b/tests/harness-conformance/harness/nav-spike/hooks/s4_userpromptsubmit.py
@@ -1,0 +1,40 @@
+"""S4 — UserPromptSubmit block-as-answer probe (Tier-1 candidate; TASK-57, mem-034).
+
+Trigger: the EXACT prompt "nav spike ping". Variants (from arm file):
+  "block-json" — print {"decision": "block", "reason": <answer+sentinel>}, exit 0
+  "exit-2"     — print answer+sentinel on stderr, exit 2
+
+Echo hygiene (mem-034): the served answer must never contain the trigger
+phrase, so a re-echo cannot re-trigger the hook. Non-trigger prompts are
+logged (proof the hook ran without blocking) and passed through.
+"""
+
+import sys
+from pathlib import Path
+import json
+
+sys.path.insert(0, str(Path(__file__).parent))
+from spike_gate import gate, log
+
+payload, arm = gate("s4")
+prompt = (payload.get("prompt") or "").strip()
+
+if prompt != "nav spike ping":
+    log("s4", {"event": "non-trigger-passthrough", "prompt_head": prompt[:80]})
+    sys.exit(0)
+
+sentinel = arm["sentinel"]
+variant = arm.get("variant", "block-json")
+answer = (
+    f"PONG — served deterministically by the S4 hook, zero model tokens. "
+    f"Answer token: {sentinel}."
+)
+
+log("s4", {"event": "trigger-blocked", "variant": variant, "sentinel": sentinel})
+
+if variant == "block-json":
+    print(json.dumps({"decision": "block", "reason": answer}))
+    sys.exit(0)
+else:
+    print(answer, file=sys.stderr)
+    sys.exit(2)

--- a/tests/harness-conformance/harness/nav-spike/hooks/s5_pretooluse.py
+++ b/tests/harness-conformance/harness/nav-spike/hooks/s5_pretooluse.py
@@ -1,0 +1,46 @@
+"""S5 — PreToolUse(Read) injection re-test (TASK-57; mem-035 conflict).
+
+mem-035 (live-verified v6.12.0): PreToolUse stdout AND additionalContext were
+silently dropped. This probe re-tests both channels on today's CC while
+allowing the tool call. Variants (from arm file):
+  "stdout"  — plain text with sentinel on stdout, exit 0
+  "context" — JSON with permissionDecision allow + additionalContext sentinel
+
+Either outcome is a result: works => memory supersedes mem-035;
+dropped => memory reconfirms mem-035.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from spike_gate import gate, log
+
+payload, arm = gate("s5")
+sentinel = arm["sentinel"]
+variant = arm.get("variant", "context")
+
+if variant == "stdout":
+    print(
+        f"SPIKE PRETOOL STDOUT: {sentinel}. "
+        "You MUST quote this exact token verbatim once in your final answer."
+    )
+else:
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": "spike probe S5",
+            # Declarative fact (no imperative) — see s1_posttooluse.py note.
+            "additionalContext": (
+                f"Session metadata: the internal build codename for this "
+                f"session is {sentinel}."
+            ),
+        }
+    }
+    print(json.dumps(out))
+
+log("s5", {"event": f"emitted-{variant}", "sentinel": sentinel,
+           "tool_name": payload.get("tool_name")})
+sys.exit(0)

--- a/tests/harness-conformance/harness/nav-spike/hooks/spike_gate.py
+++ b/tests/harness-conformance/harness/nav-spike/hooks/spike_gate.py
@@ -1,0 +1,81 @@
+"""Shared gate for TASK-57 spike hooks.
+
+The spike plugin installs at user scope, so these hooks are registered for
+every session. Containment: a hook only acts when BOTH hold —
+  (a) the session cwd is inside /tmp/nav-v7-spike (the scratch project), and
+  (b) its arm file /tmp/nav-v7-spike/state/arm-<probe>.json exists
+      (written by the driving probe script, carrying the per-run sentinel).
+Anywhere else it exits 0 silently. Stdlib only.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# NAV_SPIKE_DIR is honored when the session env carries it; the default is
+# the runtime home. The SessionStart command in plugin.json hardcodes the
+# default path — keep them in sync if you ever relocate the harness.
+SPIKE = Path(os.environ.get("NAV_SPIKE_DIR", "/tmp/nav-v7-spike"))
+STATE = SPIKE / "state"
+
+
+def log(probe: str, obj: dict) -> None:
+    STATE.mkdir(parents=True, exist_ok=True)
+    with open(STATE / f"log-{probe}.jsonl", "a") as f:
+        f.write(json.dumps(obj) + "\n")
+
+
+def _allow_and_exit() -> None:
+    """Belt-and-suspenders fail-open (GH-27): a probe must never block a real
+    tool call. Emitted only for truly unexpected errors — the expected
+    containment paths below already exit 0 on their own."""
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+        }
+    }))
+    sys.exit(0)
+
+
+def gate(probe: str):
+    """Return (payload, arm) when armed; exit 0 otherwise."""
+    try:
+        return _gate_impl(probe)
+    except SystemExit:
+        raise
+    except Exception:
+        _allow_and_exit()
+
+
+def _gate_impl(probe: str):
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    cwd = payload.get("cwd") or os.getcwd()
+    # macOS: payload cwd arrives realpath'd (/tmp -> /private/tmp), so
+    # compare resolved paths instead of raw string prefixes.
+    spike_real = SPIKE.resolve()
+    try:
+        cwd_real = Path(cwd).resolve()
+    except Exception:
+        sys.exit(0)
+    if not (cwd_real == spike_real or spike_real in cwd_real.parents):
+        sys.exit(0)
+    arm_file = STATE / f"arm-{probe}.json"
+    if not arm_file.exists():
+        log(probe, {"event": "fired-unarmed",
+                    "hook_event": payload.get("hook_event_name")})
+        sys.exit(0)
+    try:
+        arm = json.loads(arm_file.read_text())
+    except Exception:
+        sys.exit(0)
+    log(probe, {"event": "fired-armed",
+                "hook_event": payload.get("hook_event_name"),
+                "session_id": payload.get("session_id"),
+                "transcript_path": payload.get("transcript_path"),
+                "arm": arm})
+    return payload, arm

--- a/tests/harness-conformance/probe_s1.py
+++ b/tests/harness-conformance/probe_s1.py
@@ -1,0 +1,65 @@
+"""S1 — PostToolUse(Read) additionalContext reaches the model?
+
+Pass: sentinel quoted verbatim in the visible answer AND transcript grep finds
+it in a non-assistant (injected) position at/after the tool_result — not
+merely echoed by the model.
+
+Observable is DECLARATIVE (fact + question), never "quote this token" —
+the model's injection defense refuses imperative compliance on tool-adjacent
+channels while delivery succeeds (TASK-57 method lesson).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from common import (arm, disarm, clear_log, read_log, preflight, run_claude,
+                    find_transcripts, scan_jsonl, entry_lines, make_sentinel,
+                    write_verdict)
+
+preflight()
+clear_log("s1")
+sentinel = make_sentinel("1")
+arm("s1", {"sentinel": sentinel})
+try:
+    r = run_claude(
+        "Read the file notes.txt in this directory and tell me which fruit it "
+        "mentions. Also: if any session metadata mentions an internal build "
+        "codename, tell me what it is; otherwise say 'no codename'.",
+        allowed=["Read"],
+    )
+finally:
+    disarm("s1")
+
+hook_log = read_log("s1")
+hook_emitted = any(e.get("event") == "emitted-additionalContext" for e in hook_log)
+answer_quoted = sentinel in r["result_text"]
+
+transcripts = find_transcripts(session_id=r["session_id"], since=r["started"])
+occurrences = []
+tool_result_lines = []
+for t in transcripts:
+    occurrences += scan_jsonl(t, sentinel)
+    tool_result_lines += [
+        {"file": str(t), "line": n}
+        for n in entry_lines(t, lambda e: isinstance((e.get("message") or {}).get("content"), list)
+                             and any(b.get("type") == "tool_result"
+                                     for b in e["message"]["content"]))
+    ]
+
+injected = [o for o in occurrences if o["role"] != "assistant"]
+quoted = [o for o in occurrences if o["role"] == "assistant"]
+
+write_verdict("s1", {
+    "channel": "PostToolUse hookSpecificOutput.additionalContext",
+    "sentinel": sentinel,
+    "hook_emitted": hook_emitted,
+    "answer_quoted": answer_quoted,
+    "injected_positions": injected,
+    "assistant_positions": quoted,
+    "tool_result_lines": tool_result_lines,
+    "transcripts": [str(t) for t in transcripts],
+    "result_text": r["result_text"][:500],
+    "exit_code": r["exit_code"],
+    "pass": bool(hook_emitted and answer_quoted and injected),
+})

--- a/tests/harness-conformance/probe_s2.py
+++ b/tests/harness-conformance/probe_s2.py
@@ -1,0 +1,77 @@
+"""S2 — Stop forced continuation: continue:true vs decision:block, with fuse.
+
+Run A (fresh session): variant continue:true; expect one continuation carrying
+the sentinel, then the run-twice subtest (same session, second prompt) must
+produce ZERO further continuations (fuse consumed, mem-037).
+Run B (fresh session, fresh fuse): variant decision:block — the routing-matrix
+fallback — probed for comparison evidence.
+
+Both variants count as ONE probe run. The top-level "pass" tracks
+continue:true specifically; when it is false but decision_block_works is
+true, the channel verdict is "decision:block is the forced-continuation
+mechanism" (observed CC 2.1.205, mem-051) — record that outcome, don't
+weaken this criterion.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from common import (STATE, arm, disarm, clear_log, read_log, preflight,
+                    run_claude, find_transcripts, scan_jsonl, make_sentinel,
+                    write_verdict)
+
+preflight()
+results = {}
+
+for variant in ("continue", "block"):
+    clear_log("s2")
+    fuse = STATE / "fuse-s2"
+    if fuse.exists():
+        fuse.unlink()
+    sentinel = make_sentinel(f"2{variant[0].upper()}")
+    arm("s2", {"sentinel": sentinel, "variant": variant})
+    try:
+        r1 = run_claude("Say the word hello and nothing else.")
+        fuse_after_r1 = fuse.exists()
+        # Run-twice subtest in the SAME session: fuse present => no continuation.
+        r2 = run_claude("Say the word goodbye and nothing else.",
+                        resume=r1["session_id"]) if r1["session_id"] else None
+    finally:
+        disarm("s2")
+
+    log = read_log("s2")
+    transcripts = find_transcripts(session_id=r1["session_id"], since=r1["started"])
+    occurrences = []
+    for t in transcripts:
+        occurrences += scan_jsonl(t, sentinel)
+    continued = sentinel in r1["result_text"] or any(
+        o["role"] == "assistant" for o in occurrences)
+    second_run_events = [e["event"] for e in log
+                         if e.get("event") in ("fuse-present-silent-exit",
+                                               "stop_hook_active-short-circuit")]
+    r2_clean = bool(r2) and sentinel not in (r2["result_text"] or "")
+
+    results[variant] = {
+        "sentinel": sentinel,
+        "continuation_happened": continued,
+        "fuse_consumed": fuse_after_r1,
+        "run_twice_no_continuation": r2_clean,
+        "second_run_hook_events": second_run_events,
+        "occurrences": occurrences,
+        "r1_result": r1["result_text"][:300],
+        "r2_result": (r2 or {}).get("result_text", "")[:300],
+        "r1_num_turns": (r1["parsed"] or {}).get("num_turns"),
+        "hook_log": log,
+        "transcripts": [str(t) for t in transcripts],
+    }
+
+write_verdict("s2", {
+    "channel": "Stop continue:true (variant A) vs decision:block (variant B)",
+    "variants": results,
+    "continue_true_works": results["continue"]["continuation_happened"],
+    "decision_block_works": results["block"]["continuation_happened"],
+    "pass": bool(results["continue"]["continuation_happened"]
+                 and results["continue"]["fuse_consumed"]
+                 and results["continue"]["run_twice_no_continuation"]),
+})

--- a/tests/harness-conformance/probe_s3.py
+++ b/tests/harness-conformance/probe_s3.py
@@ -1,0 +1,64 @@
+"""S3 — SubagentStart additionalContext + both-way isolation.
+
+Sentinel A injected via SubagentStart hook; sentinel B lives only in the main
+thread's driving prompt. Pass: A visible on the subagent side (sidechain
+context + quoted in the subagent's answer), NOT injected into main-thread
+context before the Task result; B absent from sidechain entries.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from common import (arm, disarm, clear_log, read_log, preflight, run_claude,
+                    find_transcripts, scan_jsonl, make_sentinel, write_verdict)
+
+preflight()
+clear_log("s3")
+a = make_sentinel("3A")
+b = make_sentinel("3B")
+arm("s3", {"sentinel": a})
+try:
+    r = run_claude(
+        "Use the Task tool to launch one subagent (subagent_type: general-purpose) "
+        "with exactly this prompt: 'What is the capital of France? Answer in one word.' "
+        "Then report the subagent's final answer verbatim. "
+        f"Main-thread-only marker (do NOT include it in the subagent prompt): {b}",
+        allowed=["Task"],
+        timeout=420,
+    )
+finally:
+    disarm("s3")
+
+hook_log = read_log("s3")
+event_fired = any(e.get("event") == "emitted-additionalContext" for e in hook_log)
+
+transcripts = find_transcripts(session_id=r["session_id"], since=r["started"])
+occ_a, occ_b = [], []
+for t in transcripts:
+    occ_a += scan_jsonl(t, a)
+    occ_b += scan_jsonl(t, b)
+
+a_sidechain = [o for o in occ_a if o["is_sidechain"] or "subagents" in o["file"]]
+a_main = [o for o in occ_a if not (o["is_sidechain"] or "subagents" in o["file"])]
+# A relayed back inside the Task tool_result is expected; a leak means A in
+# main-thread entries whose blocks are NOT tool_result relays.
+a_main_leak = [o for o in a_main
+               if not any(bt in ("tool_result", "toolUseResult", "entry.toolUseResult")
+                          for bt in o["block_types"])
+               and o["role"] == "user"]
+b_sidechain = [o for o in occ_b if o["is_sidechain"] or "subagents" in o["file"]]
+
+write_verdict("s3", {
+    "channel": "SubagentStart hookSpecificOutput.additionalContext",
+    "sentinel_a": a, "sentinel_b": b,
+    "event_fired": event_fired,
+    "hook_log": hook_log,
+    "a_sidechain_positions": a_sidechain,
+    "a_main_positions": a_main,
+    "a_main_leaks": a_main_leak,
+    "b_sidechain_positions": b_sidechain,
+    "result_text": r["result_text"][:500],
+    "transcripts": [str(t) for t in transcripts],
+    "pass": bool(event_fired and a_sidechain and not a_main_leak and not b_sidechain),
+})

--- a/tests/harness-conformance/probe_s4.py
+++ b/tests/harness-conformance/probe_s4.py
@@ -1,0 +1,79 @@
+"""S4 — UserPromptSubmit block-as-answer (Tier-1 candidate; mem-034 hygiene).
+
+Variant A: {"decision":"block","reason":<answer>}; variant B: exit 2 + stderr.
+Pass per variant: zero model invocation on the blocked turn; then an unrelated
+follow-up in the same session must not re-trigger the hook and must answer
+normally. Rendering (stdout/stderr shape) is captured for the winner call.
+
+Both variants count as ONE probe run. Known CC 2.1.205 behavior (mem-053):
+CC appends "Original prompt: <trigger>" to block messages — transcript-scanning
+hooks must tolerate it; winner is decision:block (exit-2 leaks hook chrome).
+"""
+
+import sys
+from pathlib import Path
+import json
+
+sys.path.insert(0, str(Path(__file__).parent))
+from common import (arm, disarm, clear_log, read_log, preflight, run_claude,
+                    find_transcripts, scan_jsonl, entry_lines, make_sentinel,
+                    write_verdict)
+
+preflight()
+results = {}
+
+for variant in ("block-json", "exit-2"):
+    clear_log("s4")
+    sentinel = make_sentinel(f"4{'A' if variant == 'block-json' else 'B'}")
+    arm("s4", {"sentinel": sentinel, "variant": variant})
+    try:
+        r1 = run_claude("nav spike ping")
+        r2 = (run_claude("What is 2+2? Answer with just the number.",
+                         resume=r1["session_id"])
+              if r1["session_id"] else
+              run_claude("What is 2+2? Answer with just the number."))
+    finally:
+        disarm("s4")
+
+    log = read_log("s4")
+    blocked = any(e.get("event") == "trigger-blocked" for e in log)
+    followup_passthrough = any(e.get("event") == "non-trigger-passthrough"
+                               for e in log)
+
+    transcripts = find_transcripts(session_id=r1["session_id"], since=r1["started"])
+    if r2["session_id"]:
+        transcripts += [t for t in find_transcripts(session_id=r2["session_id"])
+                        if t not in transcripts]
+    assistant_lines, occurrences = [], []
+    for t in transcripts:
+        occurrences += scan_jsonl(t, sentinel)
+        assistant_lines += entry_lines(
+            t, lambda e: e.get("type") == "assistant")
+
+    results[variant] = {
+        "sentinel": sentinel,
+        "hook_blocked": blocked,
+        "blocked_turn_exit_code": r1["exit_code"],
+        "blocked_turn_stdout": r1["stdout"][:800],
+        "blocked_turn_stderr": r1["stderr"][:800],
+        "sentinel_in_cli_output": sentinel in (r1["stdout"] + r1["stderr"]),
+        "followup_hook_passthrough": followup_passthrough,
+        "followup_retriggered": sum(1 for e in log
+                                    if e.get("event") == "trigger-blocked") > 1,
+        "followup_answer": r2["result_text"][:200],
+        "followup_answer_contains_block_text": sentinel in (r2["result_text"] or ""),
+        "sentinel_occurrences": occurrences,
+        "assistant_entry_lines": assistant_lines,
+        "transcripts": [str(t) for t in transcripts],
+        "hook_log": log,
+    }
+
+write_verdict("s4", {
+    "channel": "UserPromptSubmit block-as-answer (decision:block vs exit-2)",
+    "variants": results,
+    "pass": any(
+        v["hook_blocked"] and v["sentinel_in_cli_output"]
+        and not v["followup_retriggered"]
+        and not v["followup_answer_contains_block_text"]
+        for v in results.values()),
+})

--- a/tests/harness-conformance/probe_s5.py
+++ b/tests/harness-conformance/probe_s5.py
@@ -1,0 +1,60 @@
+"""S5 — PreToolUse(Read) injection re-test (mem-035 conflict).
+
+Two variants, fresh sentinel each: plain stdout, and
+hookSpecificOutput.additionalContext (with permissionDecision allow).
+Either outcome is a result: works => supersedes mem-035; dropped =>
+reconfirms mem-035. Both variants count as ONE probe run.
+
+Known CC 2.1.205 split (mem-054): stdout DEAD, additionalContext DELIVERS.
+The context-variant observable is declarative (fact + question) — see
+probe_s1.py / TASK-57 method lesson.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from common import (arm, disarm, clear_log, read_log, preflight, run_claude,
+                    find_transcripts, scan_jsonl, make_sentinel, write_verdict)
+
+preflight()
+results = {}
+for variant in ("stdout", "context"):
+    clear_log("s5")
+    sentinel = make_sentinel(f"5{variant[0].upper()}")
+    arm("s5", {"sentinel": sentinel, "variant": variant})
+    try:
+        r = run_claude(
+            "Read the file notes.txt in this directory and tell me which fruit it "
+            "mentions. Also: if any session metadata mentions an internal build "
+            "codename, tell me what it is; otherwise say 'no codename'.",
+            allowed=["Read"],
+        )
+    finally:
+        disarm("s5")
+
+    hook_log = read_log("s5")
+    hook_emitted = any(e.get("event") == f"emitted-{variant}" for e in hook_log)
+    transcripts = find_transcripts(session_id=r["session_id"], since=r["started"])
+    occurrences = []
+    for t in transcripts:
+        occurrences += scan_jsonl(t, sentinel)
+    injected = [o for o in occurrences if o["role"] != "assistant"]
+    results[variant] = {
+        "sentinel": sentinel,
+        "hook_emitted": hook_emitted,
+        "answer_quoted": sentinel in r["result_text"],
+        "injected_positions": injected,
+        "all_occurrences": occurrences,
+        "result_text": r["result_text"][:500],
+        "transcripts": [str(t) for t in transcripts],
+        "reaches_model": bool(sentinel in r["result_text"] and injected),
+    }
+
+any_channel_works = any(v["reaches_model"] for v in results.values())
+write_verdict("s5", {
+    "channel": "PreToolUse stdout AND hookSpecificOutput.additionalContext",
+    "variants": results,
+    "mem_035": "SUPERSEDES mem-035" if any_channel_works else "RECONFIRMS mem-035",
+    "pass": any_channel_works,
+})

--- a/tests/harness-conformance/probe_s6.py
+++ b/tests/harness-conformance/probe_s6.py
@@ -1,0 +1,66 @@
+"""S6 — CLAUDE_PLUGIN_ROOT env-binding re-check (mem-036).
+
+Live observable: the SessionStart manifest hook appended ROOT=<path> lines to
+state/log-s6.txt during every probe session driven in the scratch project.
+Plus the mem-036 three-variant shell test of the exact manifest command shape:
+env unset, empty, explicitly bound.
+
+Known CC 2.1.205 behavior (mem-055): ROOT binds to the marketplace SOURCE
+path for dir-source installs; unset is a LOUD failure, not a silent no-op.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from common import SPIKE, STATE, preflight, write_verdict, run_claude
+
+preflight()
+
+log_file = STATE / "log-s6.txt"
+if not log_file.exists() or not log_file.read_text().strip():
+    # Ensure at least one live session has run in the scratch project.
+    run_claude("Say the word ok and nothing else.")
+
+lines = [l for l in log_file.read_text().splitlines() if l.strip()] \
+    if log_file.exists() else []
+root_values = [l.split("ROOT=", 1)[1].split(" PWD=")[0] for l in lines
+               if l.startswith("ROOT=")]
+live_bound = [v for v in root_values if v.strip()]
+points_into_install = any("plugin" in v or "marketplace" in v.lower()
+                          for v in live_bound)
+
+# mem-036 three-variant shell test against the real python-hook command shape.
+manifest = json.loads((SPIKE / "marketplace" / "nav-spike" / ".claude-plugin"
+                       / "plugin.json").read_text())
+cmd = manifest["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+variants = {}
+for name, env_extra in (
+    ("unset", {"CLAUDE_PLUGIN_ROOT": None}),
+    ("empty", {"CLAUDE_PLUGIN_ROOT": ""}),
+    ("bound", {"CLAUDE_PLUGIN_ROOT": str(live_bound[-1]) if live_bound else ""}),
+):
+    env = dict(os.environ)
+    for k, v in env_extra.items():
+        if v is None:
+            env.pop(k, None)
+        else:
+            env[k] = v
+    proc = subprocess.run(["sh", "-c", cmd], env=env, capture_output=True,
+                          text=True, input="{}", timeout=15)
+    variants[name] = {"exit_code": proc.returncode,
+                      "stdout": proc.stdout[:200], "stderr": proc.stderr[:300],
+                      "silent_noop": proc.returncode == 0 and not proc.stdout
+                      and not proc.stderr}
+
+write_verdict("s6", {
+    "channel": "${CLAUDE_PLUGIN_ROOT} manifest binding",
+    "live_log_lines": lines[-10:],
+    "live_bound_values": sorted(set(live_bound)),
+    "points_into_install": points_into_install,
+    "shell_variants": variants,
+    "pass": bool(live_bound and points_into_install),
+})

--- a/tests/harness-conformance/results/cc-2.1.205.json
+++ b/tests/harness-conformance/results/cc-2.1.205.json
@@ -1,0 +1,49 @@
+{
+  "cc_version": "2.1.205",
+  "date": "2026-07-10",
+  "recorded_by": "Aleks Petrov",
+  "probes": {
+    "s1": {
+      "pass": true,
+      "channel_works": true,
+      "verdict_file": "/tmp/nav-v7-spike/state/verdict-s1.json",
+      "memory": "mem-050",
+      "summary": "PostToolUse additionalContext DELIVERS: declarative-fact sentinel quoted in the visible answer, injected (non-assistant) positions found adjacent to the tool_result. Supersedes mem-035 for this sub-channel."
+    },
+    "s2": {
+      "pass": false,
+      "channel_works": true,
+      "verdict_file": "/tmp/nav-v7-spike/state/verdict-s2.json",
+      "memory": "mem-051",
+      "summary": "Stop continue:true is a NO-OP (probe pass tracks continue:true, hence false); decision:block+reason forces the continuation and is the working mechanism — channel_works refers to decision:block. Single-shot fuse consumed; run-twice subtest produced zero further continuations (mem-037 belt verified)."
+    },
+    "s3": {
+      "pass": true,
+      "channel_works": true,
+      "verdict_file": "/tmp/nav-v7-spike/state/verdict-s3.json",
+      "memory": "mem-052",
+      "summary": "SubagentStart additionalContext WORKS: sentinel A present in subagent sidechain context, zero main-thread leaks outside tool_result relays, main-thread-only sentinel B absent from the sidechain (both-way isolation holds)."
+    },
+    "s4": {
+      "pass": true,
+      "channel_works": true,
+      "verdict_file": "/tmp/nav-v7-spike/state/verdict-s4.json",
+      "memory": "mem-053",
+      "summary": "UserPromptSubmit block-as-answer WORKS in both variants with zero model invocation (num_turns=0); no hook re-trigger and no block-text echo on the follow-up (mem-034 hygiene). Winner remains decision:block — exit-2 leaks hook command chrome in interactive rendering."
+    },
+    "s5": {
+      "pass": true,
+      "channel_works": true,
+      "verdict_file": "/tmp/nav-v7-spike/state/verdict-s5.json",
+      "memory": "mem-054",
+      "summary": "PreToolUse split unchanged: stdout DEAD (reconfirms mem-035 for stdout), additionalContext DELIVERS (supersedes mem-035 for that sub-channel) — channel_works is true for additionalContext only. read_guard stays deny-only per plan."
+    },
+    "s6": {
+      "pass": true,
+      "channel_works": true,
+      "verdict_file": "/tmp/nav-v7-spike/state/verdict-s6.json",
+      "memory": "mem-055",
+      "summary": "CLAUDE_PLUGIN_ROOT binds to the marketplace SOURCE path (/tmp/nav-v7-spike/marketplace/nav-spike) for dir-source installs; unset and empty variants fail LOUD (exit 2), not as silent no-ops — the mem-036 failure class did not reproduce."
+    }
+  }
+}

--- a/tests/harness-conformance/run.md
+++ b/tests/harness-conformance/run.md
@@ -1,0 +1,238 @@
+# Harness-Conformance Suite — Drive Script (TASK-58)
+
+Re-runnable packaging of the six TASK-57 hook-channel probes (S1–S6). Run this
+suite against every Claude Code version Navigator v7 ships on; check the result
+in as `results/cc-<version>.json`. `make conformance-check` fails loudly when no
+results file exists for the installed CC version.
+
+**This suite is CI-adjacent, not CI**: probes drive live headless CC sessions
+and need human judgment for rendering checks. Only the results-file existence
+check (`make conformance-check`) and the schema test (`make test`) automate.
+
+**Independence rule**: probes and `common.py` are stdlib-only and import
+nothing from `hooks/` or `nav_hook_lib` — the suite certifies the harness the
+runtime runs on, so it must not depend on the runtime (TASK-59 runs parallel).
+
+---
+
+## The probe + memory pairing rule (standing)
+
+**New harness discovery → new probe + new memory, always paired.**
+A memory without a probe is archaeology; a probe without a memory is
+unexplained. Current pairing:
+
+| Probe | Channel | Memory |
+|-------|---------|--------|
+| S1 | PostToolUse `additionalContext` | mem-050 |
+| S2 | Stop `continue:true` vs `decision:block` (fuse, mem-037) | mem-051 |
+| S3 | SubagentStart `additionalContext` + isolation | mem-052 |
+| S4 | UserPromptSubmit block-as-answer (mem-034 hygiene) | mem-053 |
+| S5 | PreToolUse stdout + `additionalContext` (mem-035 re-test) | mem-054 |
+| S6 | `${CLAUDE_PLUGIN_ROOT}` binding (mem-036 re-check) | mem-055 |
+
+Memory recall takes comma-separated concepts:
+`python3 skills/nav-graph/functions/memory_recall.py --concepts "hooks,harness-behavior"`
+
+---
+
+## Method lessons (read before editing any probe)
+
+1. **Injection observable — declarative, never imperative.** On tool-adjacent
+   channels (PreToolUse/PostToolUse), NEVER use "quote this token verbatim" as
+   the observable: the model's injection defense refuses compliance while
+   delivery succeeds, producing a false FAIL (observed 2/2 on CC 2.1.205).
+   Use a **declarative fact plus a driving-prompt question only answerable
+   from that fact** — e.g. hook injects "the internal build codename is
+   NAV-S1-xxxx", prompt asks "if any session metadata mentions an internal
+   build codename, tell me what it is; otherwise say 'no codename'".
+2. **macOS realpath.** Hook payload `cwd` arrives realpath'd
+   (`/tmp` → `/private/tmp`). Never string-prefix-gate on cwd; compare
+   `Path.resolve()`d paths (see `harness/nav-spike/hooks/spike_gate.py`).
+3. **Sentinels are per-run UUIDs** (`NAV-S<n>-<uuid8>`, `common.make_sentinel`),
+   never static strings — a static sentinel in the transcript from a previous
+   run false-passes the position grep (mem-034 class).
+4. **Silent hooks leave no transcript attachment** — conformance evidence needs
+   the side-channel logs in `$NAV_SPIKE_DIR/state/` (mem-055).
+
+---
+
+## 1. Setup — scratch marketplace from `harness/`
+
+The harness must run through **real marketplace manifest execution** — never
+ad-hoc `.claude/settings.json` hooks, which mask `${CLAUDE_PLUGIN_ROOT}`
+binding failures (mem-036).
+
+```bash
+# From the navigator repo root:
+export NAV_SPIKE_DIR=/tmp/nav-v7-spike     # default; the /tmp path is the runtime home
+
+mkdir -p "$NAV_SPIKE_DIR/project" "$NAV_SPIKE_DIR/state"
+cp -R tests/harness-conformance/harness/. "$NAV_SPIKE_DIR/marketplace/"
+printf 'The mango is ripe. Nothing else matters.\n' > "$NAV_SPIKE_DIR/project/notes.txt"
+```
+
+Note: if you change `NAV_SPIKE_DIR` from the default, also update the
+hardcoded `/tmp/nav-v7-spike` path inside the `SessionStart` command in
+`marketplace/nav-spike/.claude-plugin/plugin.json`, and export the variable in
+the shell that launches `claude` so `spike_gate.py` sees it.
+
+**Preflight (mem-036)** — the scratch project must have no settings backstop
+and no `.agent/`:
+
+```bash
+test ! -e "$NAV_SPIKE_DIR/project/.claude/settings.json" && \
+test ! -d "$NAV_SPIKE_DIR/project/.agent" && echo "preflight OK"
+```
+
+**Install** (user scope — the gate keeps hooks inert outside the scratch
+project):
+
+```bash
+claude plugin marketplace add "$NAV_SPIKE_DIR/marketplace"
+claude plugin install nav-spike@nav-spike-marketplace
+claude --version        # goes into the results filename and every verdict
+```
+
+Verify the install took: `claude plugin list` shows
+`nav-spike@nav-spike-marketplace ... enabled`.
+
+---
+
+## 2. Drive the probes — SERIAL ONLY
+
+**Arm files (`$NAV_SPIKE_DIR/state/arm-s<n>.json`) are global state**: a probe
+arms its hook for every session in the scratch project. Two probes running
+concurrently cross-fire hooks into each other's sessions and corrupt both
+verdicts. Run strictly one at a time, in order:
+
+```bash
+cd tests/harness-conformance
+python3 probe_s1.py     # ~1 min  (1 headless turn)
+python3 probe_s2.py     # ~4 min  (2 variants x 2 turns; both variants = ONE probe run)
+python3 probe_s3.py     # ~2-7 min (subagent turn, timeout 420s)
+python3 probe_s4.py     # ~2 min  (2 variants x 2 turns; both variants = ONE probe run)
+python3 probe_s5.py     # ~2 min  (2 variants x 1 turn; both variants = ONE probe run)
+python3 probe_s6.py     # seconds (reads log-s6.txt; drives 1 turn only if empty)
+```
+
+Each probe prints its verdict JSON and writes
+`$NAV_SPIKE_DIR/state/verdict-s<n>.json`. Probes always disarm in a `finally`
+block; if you abort one mid-run, check `state/` for stale `arm-*.json` files
+before continuing.
+
+### Pass criteria per probe
+
+**S1 — PostToolUse `additionalContext`** (`pass` true iff all):
+- `hook_emitted` — hook log shows `emitted-additionalContext`;
+- `answer_quoted` — the sentinel (codename) appears in the visible answer;
+- `injected_positions` non-empty — transcript grep finds the sentinel in a
+  non-assistant position (injected near the tool_result, not merely echoed).
+
+**S2 — Stop forced continuation** (single-shot fuse per mem-037):
+- Probe-level `pass` tracks **`continue:true`** specifically: continuation
+  carries the sentinel AND fuse consumed AND run-twice subtest shows zero
+  further continuations. Do not weaken this criterion.
+- Spike-gated outcome: on CC 2.1.205 `continue:true` is a NO-OP
+  (`pass: false`) while `decision:block` forces the continuation
+  (`decision_block_works: true`). Record whichever outcome you observe —
+  the results file asserts observation, not hope. `channel_works` in the
+  results file means "a forced-continuation mechanism exists".
+- If continuation loops despite the fuse: record as circuit-breaker evidence
+  for TASK-62 — that is a new discovery (pairing rule applies).
+
+**S3 — SubagentStart `additionalContext` + both-way isolation** (`pass` iff):
+- `event_fired`; sentinel A present in sidechain/subagent entries;
+- no A leak into main-thread non-tool_result positions;
+- main-thread-only sentinel B absent from sidechain entries.
+- Note: subagent transcripts are separate `<session>/subagents/agent-<id>.jsonl`
+  files (mem-052) — `find_transcripts(since=...)` catches them.
+
+**S4 — UserPromptSubmit block-as-answer** (`pass` iff for at least one variant):
+- `hook_blocked` fired on the exact trigger prompt `nav spike ping`;
+- sentinel present in CLI output with **zero model invocation** on the blocked
+  turn (check `num_turns`/usage in the verdict's `blocked_turn_stdout`);
+- echo hygiene (mem-034): unrelated follow-up does not re-trigger the hook and
+  does not contain the block text.
+- Human judgment call: compare the two variants' rendering
+  (`blocked_turn_stdout`/`stderr`) and confirm the winner. On CC 2.1.205 the
+  winner is `decision:block` — exit-2 leaks hook command chrome. Also expect
+  CC to append "Original prompt: <trigger>" to block messages (mem-053).
+
+**S5 — PreToolUse re-test (mem-035)** — either outcome is a result:
+- `pass: true` = at least one variant reaches the model (supersedes mem-035
+  for that sub-channel); `pass: false` = reconfirms mem-035.
+- On CC 2.1.205: stdout DEAD, `additionalContext` DELIVERS (mem-054) —
+  `channel_works` in the results file refers to the additionalContext
+  sub-channel. If a new CC version flips either half, that is a harness
+  change: update mem-054 and note it in the results summary.
+
+**S6 — `${CLAUDE_PLUGIN_ROOT}` binding (mem-036)** (`pass` iff):
+- live `log-s6.txt` shows non-empty `ROOT=` values pointing into the
+  marketplace install (for dir-source installs CC binds the SOURCE path,
+  i.e. `$NAV_SPIKE_DIR/marketplace/nav-spike` — mem-055);
+- three-variant shell test recorded: `unset` and `empty` must NOT be silent
+  no-ops (CC 2.1.205: loud exit-2 failure). A silent no-op on unset is a
+  regression to the mem-036 failure class — record and escalate.
+
+---
+
+## 3. Record the results file
+
+Write `results/cc-<version>.json`, where `<version>` is
+`claude --version | awk '{print $1}'` (e.g. `2.1.205`). Schema (validated by
+`test_results_schema.py` in `make test`):
+
+```json
+{
+  "cc_version": "2.1.205",
+  "date": "YYYY-MM-DD",
+  "recorded_by": "<who drove the suite>",
+  "probes": {
+    "s1": {
+      "pass": true,
+      "channel_works": true,
+      "verdict_file": "/tmp/nav-v7-spike/state/verdict-s1.json",
+      "memory": "mem-050",
+      "summary": "one-line observed outcome"
+    },
+    "s2": { "...": "same shape" },
+    "s3": { "...": "same shape" },
+    "s4": { "...": "same shape" },
+    "s5": { "...": "same shape" },
+    "s6": { "...": "same shape" }
+  }
+}
+```
+
+- `pass` — the probe script's own `pass` bool, copied from its verdict file
+  (S2 may legitimately be `false` while `channel_works` is `true`; see above).
+- `channel_works` — does a usable channel exist for this row of the v7
+  routing matrix (the thing the paired memory asserts).
+- `verdict_file` — path of the verdict JSON produced by THIS run (evidence;
+  not checked in — copy it somewhere durable if you need it later).
+- `memory` — the paired graph memory ID (table above). If the observed
+  outcome contradicts the memory, update the memory in the same change.
+- All six probes `s1`..`s6` are required; the schema test fails otherwise.
+
+Then verify:
+
+```bash
+make conformance-check                                     # exit 0
+cd tests/harness-conformance && python3 -m unittest discover -p "test_*.py"
+```
+
+---
+
+## 4. Teardown
+
+The plugin's hooks are inert outside `$NAV_SPIKE_DIR` (cwd + arm-file gate),
+so leaving it installed between runs is safe but noisy. To remove:
+
+```bash
+claude plugin uninstall nav-spike@nav-spike-marketplace
+claude plugin marketplace remove nav-spike-marketplace
+rm -rf "$NAV_SPIKE_DIR"
+```
+
+Keep `state/verdict-s*.json` copies if the run produced anything surprising —
+verdicts are the raw evidence behind the checked-in results file.

--- a/tests/harness-conformance/test_missing_script_failopen.py
+++ b/tests/harness-conformance/test_missing_script_failopen.py
@@ -1,0 +1,133 @@
+"""GH-27: a missing probe script must never block a real tool call.
+
+The nav-spike plugin can be installed at user scope with its marketplace path
+under ephemeral /tmp. If /tmp is cleaned, the hook scripts vanish (only
+__pycache__ survives) but the registration in plugin.json still points at
+them. Before this fix, `python3 <missing-file>` exited non-zero and Claude
+Code treats a non-zero PreToolUse hook as a block — bricking every Read in
+the session. This test proves two independent layers of the fix:
+
+  1. The wrapped shell command in plugin.json degrades to a no-op (exit 0)
+     when the target script is absent, without ever invoking python3.
+  2. spike_gate.gate()'s outer try/except degrades to an explicit allow
+     decision on any unexpected error, as a second line of defense.
+
+Stdlib only, no live CC session required.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PLUGIN_DIR = HERE / "harness" / "nav-spike"
+PLUGIN_JSON = PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+HOOKS_DIR = PLUGIN_DIR / "hooks"
+
+# Matches the guarded command shape:
+#   sh -c 'f="${CLAUDE_PLUGIN_ROOT}/hooks/X.py"; [ -f "$f" ] && exec python3 "$f" || exit 0'
+GUARDED_RE = re.compile(
+    r'^sh -c \'f="\$\{CLAUDE_PLUGIN_ROOT\}/hooks/(?P<script>[\w.]+)"; '
+    r'\[ -f "\$f" \] && exec python3 "\$f" \|\| exit 0\'$'
+)
+
+
+def _script_commands():
+    manifest = json.loads(PLUGIN_JSON.read_text())
+    out = []
+    for event, entries in manifest["hooks"].items():
+        if event == "SessionStart":
+            continue  # inline shell, not a python3 script invocation
+        for entry in entries:
+            for hook in entry["hooks"]:
+                out.append((event, hook["command"]))
+    return out
+
+
+class TestManifestCommandsAreGuarded(unittest.TestCase):
+    """Layer 1: every s*_*.py registration in plugin.json is a fail-open wrapper."""
+
+    def test_every_script_command_is_guarded(self):
+        commands = _script_commands()
+        self.assertTrue(commands, "expected at least one script-backed hook command")
+        for event, command in commands:
+            with self.subTest(event=event, command=command):
+                self.assertRegex(
+                    command, GUARDED_RE,
+                    f"{event} command is not wrapped with a missing-file guard: {command!r}",
+                )
+
+    def test_guarded_scripts_exist_on_disk(self):
+        """Sanity: the guard references real files, not a typo'd path."""
+        for _, command in _script_commands():
+            m = GUARDED_RE.match(command)
+            self.assertIsNotNone(m)
+            self.assertTrue(
+                (HOOKS_DIR / m.group("script")).is_file(),
+                f"{m.group('script')} referenced by manifest but missing on disk",
+            )
+
+
+class TestMissingScriptFailsOpen(unittest.TestCase):
+    """Layer 1, behavioral: run the guarded command with the script deleted."""
+
+    def _run_guarded(self, command: str, plugin_root: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["sh", "-c", command.split("sh -c ", 1)[1].strip("'").replace(
+                "${CLAUDE_PLUGIN_ROOT}", str(plugin_root)
+            )],
+            input="{}",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_missing_script_exits_zero_without_invoking_python(self):
+        for _, command in _script_commands():
+            with self.subTest(command=command):
+                # Point CLAUDE_PLUGIN_ROOT at a directory with no hooks/ at
+                # all — simulates a wiped /tmp marketplace checkout.
+                proc = self._run_guarded(command, Path("/tmp/gh-27-does-not-exist"))
+                self.assertEqual(
+                    proc.returncode, 0,
+                    f"missing script must not block: stderr={proc.stderr!r}",
+                )
+
+    def test_present_script_still_runs(self):
+        """Behavior is unchanged when the script exists (regression guard)."""
+        s5 = next(c for e, c in _script_commands() if e == "PreToolUse")
+        proc = self._run_guarded(s5, PLUGIN_DIR)
+        # s5 requires an armed, in-scratch-dir payload to do anything; here it
+        # just needs to prove python3 actually ran and the gate exited clean.
+        self.assertEqual(proc.returncode, 0, f"stderr={proc.stderr!r}")
+
+
+class TestGateFailsOpenOnUnexpectedError(unittest.TestCase):
+    """Layer 2: spike_gate.gate()'s outer try/except emits an explicit allow
+    decision and exits 0 on any error the containment checks don't already
+    catch (belt-and-suspenders per GH-27)."""
+
+    def test_gate_allows_on_unexpected_exception(self):
+        sys.path.insert(0, str(HOOKS_DIR))
+        try:
+            import spike_gate
+            import importlib
+            importlib.reload(spike_gate)
+
+            def _boom(probe):
+                raise RuntimeError("simulated unexpected failure")
+
+            spike_gate._gate_impl = _boom
+            with self.assertRaises(SystemExit) as ctx:
+                spike_gate.gate("s5")
+            self.assertEqual(ctx.exception.code, 0)
+        finally:
+            sys.path.remove(str(HOOKS_DIR))
+            sys.modules.pop("spike_gate", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/harness-conformance/test_results_schema.py
+++ b/tests/harness-conformance/test_results_schema.py
@@ -1,0 +1,108 @@
+"""Schema validation for harness-conformance results files (TASK-58).
+
+Stdlib unittest (TASK-45 pattern), no live CC needed. Validates EVERY
+results/cc-<version>.json: required keys, six probes present, version and
+date formats, filename/content consistency. Runs in `make test` via
+per-directory discovery:
+
+    cd tests/harness-conformance && python3 -m unittest discover -p "test_*.py"
+"""
+
+import datetime
+import json
+import re
+import unittest
+from pathlib import Path
+
+RESULTS_DIR = Path(__file__).resolve().parent / "results"
+FILENAME_RE = re.compile(r"^cc-(\d+\.\d+\.\d+)\.json$")
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+MEMORY_RE = re.compile(r"^mem-\d{3}$")
+
+REQUIRED_TOP_KEYS = {"cc_version", "date", "recorded_by", "probes"}
+REQUIRED_PROBES = {"s1", "s2", "s3", "s4", "s5", "s6"}
+REQUIRED_PROBE_KEYS = {"pass", "channel_works", "verdict_file", "memory", "summary"}
+
+
+def results_files():
+    if not RESULTS_DIR.is_dir():
+        return []
+    return sorted(RESULTS_DIR.glob("*.json"))
+
+
+class TestResultsSchema(unittest.TestCase):
+
+    def test_results_dir_has_at_least_one_file(self):
+        """The suite ships with a checked-in results file; zero files means
+        the conformance evidence was deleted, not merely outdated."""
+        self.assertTrue(results_files(),
+                        f"no results files found under {RESULTS_DIR}")
+
+    def test_every_results_file_matches_schema(self):
+        for path in results_files():
+            with self.subTest(file=path.name):
+                self._validate_file(path)
+
+    def _validate_file(self, path: Path):
+        m = FILENAME_RE.match(path.name)
+        self.assertIsNotNone(
+            m, f"{path.name}: filename must match cc-<major.minor.patch>.json")
+        filename_version = m.group(1)
+
+        data = json.loads(path.read_text())
+        self.assertIsInstance(data, dict, f"{path.name}: top level must be an object")
+
+        missing = REQUIRED_TOP_KEYS - set(data)
+        self.assertFalse(missing, f"{path.name}: missing top-level keys {sorted(missing)}")
+
+        # cc_version: bare version token, consistent with the filename
+        # (produced by `claude --version | awk '{print $1}'`).
+        cc_version = data["cc_version"]
+        self.assertIsInstance(cc_version, str)
+        self.assertRegex(cc_version, VERSION_RE,
+                         f"{path.name}: cc_version must be major.minor.patch")
+        self.assertEqual(cc_version, filename_version,
+                         f"{path.name}: cc_version does not match filename")
+
+        # date: YYYY-MM-DD, actually parseable
+        self.assertIsInstance(data["date"], str)
+        try:
+            datetime.datetime.strptime(data["date"], "%Y-%m-%d")
+        except ValueError:
+            self.fail(f"{path.name}: date {data['date']!r} is not YYYY-MM-DD")
+
+        self.assertIsInstance(data["recorded_by"], str)
+        self.assertTrue(data["recorded_by"].strip(),
+                        f"{path.name}: recorded_by must be non-empty")
+
+        probes = data["probes"]
+        self.assertIsInstance(probes, dict, f"{path.name}: probes must be an object")
+        self.assertEqual(set(probes), REQUIRED_PROBES,
+                         f"{path.name}: probes must be exactly s1..s6")
+
+        for name, probe in probes.items():
+            self._validate_probe(path.name, name, probe)
+
+    def _validate_probe(self, filename: str, name: str, probe):
+        ctx = f"{filename}: probes.{name}"
+        self.assertIsInstance(probe, dict, f"{ctx} must be an object")
+        missing = REQUIRED_PROBE_KEYS - set(probe)
+        self.assertFalse(missing, f"{ctx}: missing keys {sorted(missing)}")
+
+        self.assertIsInstance(probe["pass"], bool, f"{ctx}.pass must be a bool")
+        self.assertIsInstance(probe["channel_works"], bool,
+                              f"{ctx}.channel_works must be a bool")
+        self.assertIsInstance(probe["verdict_file"], str,
+                              f"{ctx}.verdict_file must be a string")
+        self.assertTrue(probe["verdict_file"].strip(),
+                        f"{ctx}.verdict_file must be non-empty")
+        self.assertIsInstance(probe["memory"], str, f"{ctx}.memory must be a string")
+        self.assertRegex(probe["memory"], MEMORY_RE,
+                         f"{ctx}.memory must look like mem-0XX")
+        self.assertIsInstance(probe["summary"], str, f"{ctx}.summary must be a string")
+        self.assertTrue(probe["summary"].strip(),
+                        f"{ctx}.summary must be non-empty")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Automated PR created by Pilot for task GH-27.

Closes #27

## Changes

GitHub Issue GH-27: fix(harness): nav-spike PreToolUse probe hard-blocks Read when its script is missing — guard for fail-open

## Context

The nav-spike harness conformance probes (`tests/harness-conformance/harness/nav-spike/hooks/s*_pretooluse.py`) can be installed as a **live user-scope plugin** (`nav-spike@nav-spike-marketplace`) whose marketplace path lives under **ephemeral `/tmp`** (`/tmp/nav-v7-spike/marketplace`). The plugin registers `PreToolUse` hooks that invoke `python3 ${CLAUDE_PLUGIN_ROOT}/hooks/s5_pretooluse.py`.

When `/tmp` is cleaned by the OS, the hook scripts are deleted (only `__pycache__` survives). The registered command then runs `python3 <missing-file>`, which exits non-zero with:

```
python3: can't open file '/tmp/nav-v7-spike/marketplace/nav-spike/hooks/s5_pretooluse.py': [Errno 2] No such file or directory
```

Claude Code treats a non-zero `PreToolUse` hook as a **block**, so **every `Read` tool call in the session (and in all subagents) fails**. A test/conformance probe must never be able to brick a real tool.

## Problem

The containment guard in `spike_gate.gate()` is already fail-open (it exits 0 unless cwd is inside `/tmp/nav-v7-spike` and an arm file exists). But that guard is in the **Python script that no longer exists** — the failure happens at the OS `exec` layer (missing file), before any Python runs. The hook *registration/command* has no existence guard.

## Fix

In the nav-spike hook registration (the plugin manifest / `hooks.json` under `tests/harness-conformance/harness/nav-spike/` that emits the `PreToolUse` command), make a missing script a **no-op instead of a block**. Wrap the command so it exits 0 when the script is absent, e.g.:

```sh
sh -c 'f="${CLAUDE_PLUGIN_ROOT}/hooks/s5_pretooluse.py"; [ -f "$f" ] && exec python3 "$f" || exit 0'
```

Apply the same guard to every `s*_pretooluse.py` / `s*_posttooluse.py` probe the manifest registers. Belt-and-suspenders: also add a top-level `try/except SystemExit`-safe wrapper in `spike_gate.gate()` that, on ANY unexpected error, emits `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}` and exits 0.

## Acceptance

- With the probe script removed (simulate a wiped `/tmp` install), triggering a `Read` **does not block** — the tool proceeds, hook exits 0.
- Behavior is unchanged when the scripts are present and the session is armed inside the scratch project.
- Add a harness/unit test: missing-script path asserts exit 0 + allow (no block).

## Gate commands

```bash
make test
make conformance-check
make lint
```

## Refs

- Live repro on maintainer machine: `~/.claude/settings.json` enables `nav-spike@nav-spike-marketplace` with marketplace path `/tmp/nav-v7-spike/marketplace`; intact copy at `~/.claude/plugins/cache/nav-spike-marketplace/nav-spike/0.1.0/hooks/`.
- Source: `tests/harness-conformance/harness/nav-spike/hooks/` (`s5_pretooluse.py`, `spike_gate.py`).